### PR TITLE
support loading sprites from a path

### DIFF
--- a/demo/CAWTexturePackerSprites/CAWSpriteReader.m
+++ b/demo/CAWTexturePackerSprites/CAWSpriteReader.m
@@ -35,6 +35,14 @@
     // split file name
     NSString* file = [[filename lastPathComponent] stringByDeletingPathExtension];
 	NSString* extension = [filename pathExtension];
+    
+    // check if the filename contained a path
+    int nameLength = file.length + extension.length + 1;
+    if(nameLength < filename.length) {
+        file = [NSString stringWithFormat:@"%@%@",
+                [filename substringToIndex:filename.length - nameLength],
+                file];
+    }
 
     // check if we need to load the @2x file
 	if ([[UIScreen mainScreen] respondsToSelector:@selector(displayLinkWithTarget:selector:)] &&


### PR DESCRIPTION
Now, code like this can work: 

```
NSDictionary *spriteData = [CAWSpriteReader spritesWithContentOfFile:@"Some/Path/To/sheet.plist"];
```
