### PR TITLE
Fix animations to actually start from frame 0 per documentation

### DIFF
--- a/demo/CAWTexturePackerSprites/CAWSpriteCoreLayer.m
+++ b/demo/CAWTexturePackerSprites/CAWSpriteCoreLayer.m
@@ -73,9 +73,10 @@
     NSMutableArray *frameList = [[NSMutableArray alloc] initWithCapacity:50];
     
     numFrames = 0;
-    for(;;)
+    while(YES)
     {
-        NSObject *fr = [spriteData objectForKey:[NSString stringWithFormat:frameNames, numFrames+1]];
+        NSString* frameKey = [NSString stringWithFormat:frameNames, numFrames];
+        NSObject *fr = [spriteData objectForKey:frameKey];
         if(!fr)
         {
             break;


### PR DESCRIPTION
Documentation states that sprite frame numbers should begin at 0, but the code actually skips to frame 1. Fixed this. Also made it use a while(YES) loop which I think reads more clearly than a blank for
statement.
